### PR TITLE
Allow adding Work Dir as an optional parameter and other many small fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ RunAsService is a command line tool that allows you to setup a regular  console 
 This tool requires that .NET Framework 4.5 be already installed on your computer.
 If you do not have .NET Framework 4.5 this tool will display a message and not run.
 
-IMPORTANT: Any services you install using this tool will
+## IMPORTANT: Any services you install using this tool will
 require that this tool remain on that computer in the same
 location in order for those services to continue functioning. Therefore
 before installing any services you should make sure this tool is
@@ -12,6 +12,8 @@ somewhere where it can remain permanently. If you do end up moving
 this tool use the 'fixservices' action to fix the existing services.
 (details on how to use 'fixservices' can be found below)
 
+## Usage / Syntax
+```
 RunAsService
     Typing just the name of the tool without specifying any parameters.
     Or specifying incorrect paramters will bring you to this help 
@@ -65,38 +67,37 @@ RunAsService fixservices
         on that computer and at the same location. If you do not call 
         'fixservices' after moving this tool the existing services 
         installed using this tool will stop functioning.
+```
+## EXAMPLES
 
-# EXAMPLES
-
-RunAsService install "c:\my apps\Myapp.exe"
-
+* `RunAsService install "c:\my apps\Myapp.exe"` <br>
         Installs Myapp as a service called 'Myapp'
-
-RunAsService install "c:\my apps\Myapp.exe" arg0 arg1
+        
+* `RunAsService install "c:\my apps\Myapp.exe" arg0 arg1` <br>
         Installs Myapp as a service called 'Myapp' passes
         the arg0 and arg1 to Myapp.exe when it's started.
 
-RunAsService install "c:\my data\path" "c:\my apps\Myapp.exe" arg0 arg1
+* `RunAsService install "c:\my data\path" "c:\my apps\Myapp.exe" arg0 arg1` <br>
         Installs Myapp as a service called 'Myapp' passes
         the arg0 and arg1 to Myapp.exe when it's started.
         Use "c:\my data\path" as the working directory.
         
-RunAsService install "My Service" "c:\my apps\Myapp.exe"
+* `RunAsService install "My Service" "c:\my apps\Myapp.exe"` <br>
         Installs Myapp as a service called "My Service"
 
-RunAsService install "My Service" "My Super Cool Service" "c:\my apps\Myapp.exe"
+* `RunAsService install "My Service" "My Super Cool Service" "c:\my apps\Myapp.exe"` <br>
         Installs Myapp as a service internally called "My Service"
         when using commands like 'net start' and 'net stop' and shows
         up as "My Super Cool Service" in Window's services list.
 
-RunAsService uninstall "My Service"
+* `RunAsService uninstall "My Service"` <br>
         Uninstalls the service.
 
-RunAsService fixservices
+* `RunAsService fixservices` <br>
         Updates services installed using RunAsService to point to the
         new location.
 
-# NOTES
+## NOTES
 
 You can use Windows built in commands to start and stop your services. For example you can use:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ RunAsService
     Or specifying incorrect paramters will bring you to this help 
     screen you are currently reading.
 
-RunAsService install [Name] [Display Name] PathToExecutable [Args]
+RunAsService install [Name] [Display Name] [Work Dir] PathToExecutable [Args]
     Name
         The name of the service, if none is specified the name
         will default to the name of the executable.
@@ -36,7 +36,10 @@ RunAsService install [Name] [Display Name] PathToExecutable [Args]
         Generally the display name is longer and more descriptive
         than the name and gives the user a better idea of what
         the service is and/or does.
-
+    Work Dir
+        This is the working directory, where the executable reads and
+        writes data. If you omit it, the default working directory is
+        where the executable is.
     PathToExecutable
         The location of the application you want to run as a service.
         
@@ -74,6 +77,11 @@ RunAsService install "c:\my apps\Myapp.exe" arg0 arg1
         Installs Myapp as a service called 'Myapp' passes
         the arg0 and arg1 to Myapp.exe when it's started.
 
+RunAsService install "c:\my data\path" "c:\my apps\Myapp.exe" arg0 arg1
+        Installs Myapp as a service called 'Myapp' passes
+        the arg0 and arg1 to Myapp.exe when it's started.
+        Use "c:\my data\path" as the working directory.
+        
 RunAsService install "My Service" "c:\my apps\Myapp.exe"
         Installs Myapp as a service called "My Service"
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ RunAsService fixservices
 ## EXAMPLES
 
 * `RunAsService install "c:\my apps\Myapp.exe"` <br>
-        Installs Myapp as a service called 'Myapp'
+        Installs Myapp as a service called 'Myapp'<br>
         
 * `RunAsService install "c:\my apps\Myapp.exe" arg0 arg1` <br>
         Installs Myapp as a service called 'Myapp' passes
@@ -79,7 +79,7 @@ RunAsService fixservices
 
 * `RunAsService install "c:\my data\path" "c:\my apps\Myapp.exe" arg0 arg1` <br>
         Installs Myapp as a service called 'Myapp' passes
-        the arg0 and arg1 to Myapp.exe when it's started.
+        the arg0 and arg1 to Myapp.exe when it's started.<br>
         Use "c:\my data\path" as the working directory.
         
 * `RunAsService install "My Service" "c:\my apps\Myapp.exe"` <br>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ RunAsService is a command line tool that allows you to setup a regular  console 
 This tool requires that .NET Framework 4.5 be already installed on your computer.
 If you do not have .NET Framework 4.5 this tool will display a message and not run.
 
-## IMPORTANT: Any services you install using this tool will
+**IMPORTANT**: Any services you install using this tool will
 require that this tool remain on that computer in the same
 location in order for those services to continue functioning. Therefore
 before installing any services you should make sure this tool is

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ RunAsService install [Name] [Display Name] [Work Dir] PathToExecutable [Args]
     Name
         The name of the service, if none is specified the name
         will default to the name of the executable.
-
         You might choose to give it a different name than
         the executable to keep some kind of existing convention,
         make it friendlier or make it easier to use with commands like 

--- a/RunAsService.sln
+++ b/RunAsService.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32106.194
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RunAsService", "RunAsService\RunAsService.csproj", "{0F1E2B46-34C0-460C-A836-EB77F6237B47}"
 EndProject
@@ -16,13 +16,13 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0F1E2B46-34C0-460C-A836-EB77F6237B47}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{0F1E2B46-34C0-460C-A836-EB77F6237B47}.Debug|Any CPU.Build.0 = Debug|x86
 		{0F1E2B46-34C0-460C-A836-EB77F6237B47}.Debug|x86.ActiveCfg = Debug|x86
 		{0F1E2B46-34C0-460C-A836-EB77F6237B47}.Debug|x86.Build.0 = Debug|x86
 		{0F1E2B46-34C0-460C-A836-EB77F6237B47}.Release|Any CPU.ActiveCfg = Release|x86
 		{0F1E2B46-34C0-460C-A836-EB77F6237B47}.Release|x86.ActiveCfg = Release|x86
 		{0F1E2B46-34C0-460C-A836-EB77F6237B47}.Release|x86.Build.0 = Release|x86
 		{D92B2933-89E5-4090-A1B4-A44D2A83D7B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D92B2933-89E5-4090-A1B4-A44D2A83D7B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D92B2933-89E5-4090-A1B4-A44D2A83D7B2}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{D92B2933-89E5-4090-A1B4-A44D2A83D7B2}.Debug|x86.Build.0 = Debug|Any CPU
 		{D92B2933-89E5-4090-A1B4-A44D2A83D7B2}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/RunAsService/Program.cs
+++ b/RunAsService/Program.cs
@@ -129,7 +129,7 @@ namespace RunAsService {
                         string cmdLine = @Environment.CommandLine;
                         string executableFullPath = Path.GetFullPath(executablePath);
                         var startArg = cmdLine.IndexOf(executablePath) + executablePath.Length; // Start of raw arguments, leading space included.
-                        var executablePathAndArguments = executableFullPath + cmdLine.Substring(startArg);
+                        var executablePathAndArguments = '"' + executableFullPath + '"' + cmdLine.Substring(startArg);
 
                         
 

--- a/RunAsService/RunAsService.csproj
+++ b/RunAsService/RunAsService.csproj
@@ -14,6 +14,21 @@
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -39,6 +54,10 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>
+    </StartupObject>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -60,7 +79,13 @@
     <Content Include="Site\robots.txt" />
     <Content Include="Site\www.pcstylus.com\RedirectToAppAsServiceMessageSubmited.htm" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
* Now it can handle the quotes in arguments in a better way. The arguments will be copied raw to create the service.
* The executable will have the full path in the service with quotes, to avoid service starting error.
* Added an optional argument WorkDir  with syntax: `install service [workDir] executable args`
* The default working directory will be where the executable is, instead of in  `c:\windows\system32`